### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -26,7 +25,7 @@ platform = any
 
 [options]
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     importlib-metadata; python_version < "3.8"
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -44,7 +44,7 @@ inp_one = '''
 exp_one_str = '$int: 1'
 
 def parse_int_str(s):
-    return '$int: %s' % s
+    return f'$int: {s}'
 
 inp_pi = '''
 <?xml version="1.0" encoding="UTF-8"?>
@@ -53,7 +53,7 @@ inp_pi = '''
 exp_pi_str = '$float: 3.14'
 
 def parse_float_str(s):
-    return '$float: %s' % s
+    return f'$float: {s}'
 
 inp_nan = '''
 <?xml version="1.0" encoding="UTF-8"?>
@@ -74,7 +74,7 @@ inp_neginf = '''
 exp_neginf_str = '$constant: -Infinity'
 
 def parse_constant_str(s):
-    return '$constant: %s' % s
+    return f'$constant: {s}'
 
 @pytest.mark.parametrize('inp, kw, exp', [
     # object_hook (default: None)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -117,14 +117,14 @@ def test_tool(indent_arg, indent_jsonx, indent_json, infile, outfile, infile_jso
         cmd += [indent_arg]
 
     if infile:
-        infile = os.path.join(str(tmpdir), 'in' + input_ext)
+        infile = os.path.join(str(tmpdir), f'in{input_ext}')
         with open(infile, 'w') as f:
             f.write(input)
         cmd += [infile]
         input = None
 
     if outfile:
-        outfile = os.path.join(str(tmpdir), 'out' + output_ext)
+        outfile = os.path.join(str(tmpdir), f'out{output_ext}')
         cmd += [outfile]
         stdout = None
     else:

--- a/xson/dump.py
+++ b/xson/dump.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -80,7 +80,7 @@ def dump(obj, fp, *, skipkeys=False, check_circular=True, allow_nan=True, indent
                 for k, v in sorted(value.items(), key=lambda kv: kv[0]) if sort_keys else value.items():
                     if k is not None and not isinstance(k, (str, int, float, bool)):
                         if not skipkeys:
-                            raise TypeError('dictionary key is not of a basic type: %r' % (k,))
+                            raise TypeError(f'dictionary key is not of a basic type: {k!r}')
                         continue
                     _dump(v, name=_str(k))
 
@@ -130,7 +130,7 @@ def dump(obj, fp, *, skipkeys=False, check_circular=True, allow_nan=True, indent
 
         elif isinstance(value, (int, float)):
             if not allow_nan and (isinf(value) or isnan(value)):
-                raise ValueError('float value is out of range: %r' % value)
+                raise ValueError(f'float value is out of range: {value!r}')
 
             gen.startElementNS((JSONX_NS_URI, 'number'), None, attrs=_attrs(name))
             gen.characters(_str(value))
@@ -144,7 +144,7 @@ def dump(obj, fp, *, skipkeys=False, check_circular=True, allow_nan=True, indent
             _dump(default(value), name=name)
 
         else:
-            raise TypeError('cannot serialize object: %r' % (value,))
+            raise TypeError(f'cannot serialize object: {value!r}')
 
         if indent is not None:
             gen.ignorableWhitespace('\n')

--- a/xson/load.py
+++ b/xson/load.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -34,16 +34,16 @@ class JSONxHandler(ContentHandler, ErrorHandler):
         self.stack = [JSONxElement('root', None, None)]
 
     def startElement(self, name, attrs):
-        self._expect(False, 'unsupported non-namespaced element %s' % name)
+        self._expect(False, f'unsupported non-namespaced element {name}')
 
     def endElement(self, name):
         assert False, 'SAX parser must ensure that non-namespaced end of element does not occur'
 
     def startElementNS(self, name, qname, attrs):
         uri, localname = name
-        self._expect(uri == JSONX_NS_URI, 'unsupported namespace URI %s' % uri)
+        self._expect(uri == JSONX_NS_URI, f'unsupported namespace URI {uri}')
 
-        self._expect(self.stack[-1].localname in ('root', 'object', 'array'), '%s element cannot contain other elements' % self.stack[-1].localname)
+        self._expect(self.stack[-1].localname in ('root', 'object', 'array'), f'{self.stack[-1].localname} element cannot contain other elements')
 
         key = attrs[(None, 'name')] if (None, 'name') in attrs else None
         if self.stack[-1].localname == 'object':
@@ -58,7 +58,7 @@ class JSONxHandler(ContentHandler, ErrorHandler):
         elif localname == 'null':
             self.stack.append(JSONxElement(localname, key, None))
         else:
-            self._expect(False, 'unsupported element %s' % localname)
+            self._expect(False, f'unsupported element {localname}')
 
     def endElementNS(self, name, qname):
         uri, localname = name
@@ -102,14 +102,14 @@ class JSONxHandler(ContentHandler, ErrorHandler):
         elif container.localname == 'array':
             container.value.append(value)
         else:
-            assert False, 'unexpected container element %s' % container.localname
+            assert False, f'unexpected container element {container.localname}'
 
     def characters(self, content):
         element = self.stack[-1]
         if isinstance(element.value, StringIO):
             element.value.write(content)
         else:
-            self._expect(content.isspace(), '%s element must not have non-whitespace character content %s' % (element.localname, content))
+            self._expect(content.isspace(), f'{element.localname} element must not have non-whitespace character content {content}')
 
     def error(self, exception):
         self._expect(False, exception.getMessage())
@@ -122,7 +122,7 @@ class JSONxHandler(ContentHandler, ErrorHandler):
 
     def _expect(self, expr, msg):
         if not expr:
-            raise ValueError('%s [line %s, column %s]' % (msg, self._locator.getLineNumber(), self._locator.getColumnNumber()))
+            raise ValueError(f'{msg} [line {self._locator.getLineNumber()}, column {self._locator.getColumnNumber()}]')
 
 
 def load(fp, *, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None):


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence XSON also stops supporting it. The patch introduces the usage of f-strings - supported from Python3.6 - and unifies string representations to use it where possible.
It also enables the 'consider-using-f-string' pylint checker.