### PR TITLE
Remove the explicit `object` superclass definition from classes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,7 +17,6 @@ disable=
     too-many-arguments,
     too-many-branches,
     too-many-statements,
-    useless-object-inheritance,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [REPORTS]

--- a/xson/load.py
+++ b/xson/load.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -13,7 +13,7 @@ from xml.sax.handler import ContentHandler, ErrorHandler, feature_namespaces
 from .pkgdata import JSONX_NS_URI
 
 
-class JSONxElement(object):
+class JSONxElement:
     def __init__(self, localname, key, value):
         self.localname = localname
         self.key = key


### PR DESCRIPTION
In Python3, object is the implicit superclass. There is no need to explicitly define it.