### PR TITLE
Ensure test quality via linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,12 +10,15 @@
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    duplicate-code,
+    invalid-name,
     line-too-long,
     missing-docstring,
     no-self-use,  # disables warning in older pylint
     too-few-public-methods,
     too-many-arguments,
     too-many-branches,
+    too-many-locals,
     too-many-statements,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 

--- a/tests/test_cross_validate.py
+++ b/tests/test_cross_validate.py
@@ -6,9 +6,10 @@
 # according to those terms.
 
 import json
-import pytest
 
 from math import inf
+
+import pytest
 
 import xson
 
@@ -33,13 +34,13 @@ import xson
     'foo',
     # array (list)
     [],
-    [ None, True, False, 0, 1, -1, 42, 3.14, -1.28, inf, -inf, '', 'foo', [], {} ],
+    [None, True, False, 0, 1, -1, 42, 3.14, -1.28, inf, -inf, '', 'foo', [], {}],
     # object (dict)
     {},
-    { None: None },
-    { True: True, False: False },
-    { 0: 0, 1: 1, -1: -1, 42: 42, 3.14: 3.14, -1.28: -1.28, inf: inf, -inf: -inf },
-    { '': None, 'a': True, 'b': False, 'c': 0, 'd': 1, 'e': -1, 'foo': 42, 'g': 3.14, 'h': -1.28, 'i': inf, 'j': -inf, 'k': '', 'l': 'foo', 'm': [], 'n': {} },
+    {None: None},
+    {True: True, False: False},
+    {0: 0, 1: 1, -1: -1, 42: 42, 3.14: 3.14, -1.28: -1.28, inf: inf, -inf: -inf},
+    {'': None, 'a': True, 'b': False, 'c': 0, 'd': 1, 'e': -1, 'foo': 42, 'g': 3.14, 'h': -1.28, 'i': inf, 'j': -inf, 'k': '', 'l': 'foo', 'm': [], 'n': {}},
 ])
 def test_cross_validate(value):
     xson_repr = xson.dumps(value)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -6,10 +6,11 @@
 # according to those terms.
 
 import os
-import pytest
 
 from collections import OrderedDict
 from math import inf, nan
+
+import pytest
 
 import xson
 
@@ -96,10 +97,12 @@ exp_tuple_default = '''
 <json:array xmlns:json="http://www.ibm.com/xmlns/prod/2009/jsonx"><json:number>1</json:number><json:number>2</json:number></json:array>
 '''
 
+
 def tuple_default(val):
     if isinstance(val, tuple):
         return list(val)
     raise TypeError
+
 
 val_ordereddict = OrderedDict([(4, 3), (2, 1)])
 exp_ordereddict = '''
@@ -116,6 +119,7 @@ exp_ordereddict_mixedkeys = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <json:object xmlns:json="http://www.ibm.com/xmlns/prod/2009/jsonx"><json:string name="a">b</json:string><json:number name="1">2</json:number></json:object>
 '''
+
 
 @pytest.mark.parametrize('val, kw, exp', [
     # skipkeys (default: False)
@@ -175,9 +179,9 @@ def test_dump(val, kw, exp, tmpdir):
 
     def _dump():
         tmpfn = os.path.join(str(tmpdir), 'tmp.jsonx')
-        with open(tmpfn, 'w') as tmpf:
+        with open(tmpfn, 'w', encoding='utf-8') as tmpf:
             xson.dump(val, tmpf, **kw)
-        with open(tmpfn, 'r') as tmpf:
+        with open(tmpfn, 'r', encoding='utf-8') as tmpf:
             return tmpf.read()
 
     for dump in (_dumps, _dump):

--- a/tests/test_internet_draft.py
+++ b/tests/test_internet_draft.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,6 +6,7 @@
 # according to those terms.
 
 import json
+
 import pytest
 
 import xson
@@ -124,6 +125,7 @@ example_xson = '''
     <json:boolean name="remote">false</json:boolean>
 </json:object>
 '''
+
 
 @pytest.mark.parametrize('json_inp, xson_exp', [
     (object_json, object_xson),

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -6,9 +6,10 @@
 # according to those terms.
 
 import os
-import pytest
 
 from math import inf, isnan, nan
+
+import pytest
 
 import xson
 
@@ -26,10 +27,12 @@ exp_tuple_dict = {'$tuple': [1, 2]}
 exp_tuple = (1, 2)
 exp_list = [1, 2]
 
+
 def tuple_object_hook(obj):
     if '$tuple' in obj:
         return tuple(obj['$tuple'])
     return obj
+
 
 def tuple_list_object_pairs_hook(pairs):
     obj = dict(pairs)
@@ -37,14 +40,17 @@ def tuple_list_object_pairs_hook(pairs):
         return list(obj['$tuple'])
     return obj
 
+
 inp_one = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <json:number xmlns:json="http://www.ibm.com/xmlns/prod/2009/jsonx">1</json:number>
 '''
 exp_one_str = '$int: 1'
 
+
 def parse_int_str(s):
     return f'$int: {s}'
+
 
 inp_pi = '''
 <?xml version="1.0" encoding="UTF-8"?>
@@ -52,8 +58,10 @@ inp_pi = '''
 '''
 exp_pi_str = '$float: 3.14'
 
+
 def parse_float_str(s):
     return f'$float: {s}'
+
 
 inp_nan = '''
 <?xml version="1.0" encoding="UTF-8"?>
@@ -73,8 +81,10 @@ inp_neginf = '''
 '''
 exp_neginf_str = '$constant: -Infinity'
 
+
 def parse_constant_str(s):
     return f'$constant: {s}'
+
 
 @pytest.mark.parametrize('inp, kw, exp', [
     # object_hook (default: None)
@@ -110,9 +120,9 @@ def test_load(inp, kw, exp, tmpdir):
 
     def _load():
         tmpfn = os.path.join(str(tmpdir), 'tmp.jsonx')
-        with open(tmpfn, 'w') as tmpf:
+        with open(tmpfn, 'w', encoding='utf-8') as tmpf:
             tmpf.write(inp.strip())
-        with open(tmpfn, 'r') as tmpf:
+        with open(tmpfn, 'r', encoding='utf-8') as tmpf:
             return xson.load(tmpf, **kw)
 
     for load in (_loads, _load):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,11 +6,10 @@
 # according to those terms.
 
 import os
-import pytest
 import subprocess
 import sys
 
-import xson
+import pytest
 
 
 question_json = '''
@@ -94,49 +93,49 @@ def test_tool(indent_arg, indent_jsonx, indent_json, infile, outfile, infile_jso
     cmd = [sys.executable, '-m', 'xson.tool', '--sort-keys']
 
     if infile_json:
-        input = question_json
-        input_ext = '.json'
+        inp = question_json
+        infile_ext = '.json'
         cmd += ['--infile-json']
     else:
-        input = question_jsonx
-        input_ext = '.jsonx'
-    input = input.strip()
+        inp = question_jsonx
+        infile_ext = '.jsonx'
+    inp = inp.strip()
 
     if outfile_json:
-        expected = question_json
-        expected = indent_json(expected)
-        output_ext = '.json'
+        exp = question_json
+        exp = indent_json(exp)
+        outfile_ext = '.json'
         cmd += ['--outfile-json']
     else:
-        expected = question_jsonx
-        expected = indent_jsonx(expected)
-        output_ext = '.jsonx'
-    expected = expected.strip()
+        exp = question_jsonx
+        exp = indent_jsonx(exp)
+        outfile_ext = '.jsonx'
+    exp = exp.strip()
 
     if indent_arg:
         cmd += [indent_arg]
 
     if infile:
-        infile = os.path.join(str(tmpdir), f'in{input_ext}')
-        with open(infile, 'w') as f:
-            f.write(input)
-        cmd += [infile]
-        input = None
+        infile_name = os.path.join(str(tmpdir), f'in{infile_ext}')
+        with open(infile_name, 'w', encoding='utf-8') as f:
+            f.write(inp)
+        cmd += [infile_name]
+        inp = None
 
     if outfile:
-        outfile = os.path.join(str(tmpdir), f'out{output_ext}')
-        cmd += [outfile]
+        outfile_name = os.path.join(str(tmpdir), f'out{outfile_ext}')
+        cmd += [outfile_name]
         stdout = None
     else:
         stdout = subprocess.PIPE
 
-    result = subprocess.run(cmd, input=input, stdout=stdout, universal_newlines=True, check=True)
+    result = subprocess.run(cmd, input=inp, stdout=stdout, universal_newlines=True, check=True)
 
     if outfile:
-        with open(outfile, 'r') as f:
-            output = f.read()
+        with open(outfile_name, 'r', encoding='utf-8') as f:
+            out = f.read()
     else:
-        output = result.stdout
-    output = output.strip()
+        out = result.stdout
+    out = out.strip()
 
-    assert output == expected
+    assert out == exp

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ usedevelop = true
 deps =
     pycodestyle
     pylint
+    pytest
 commands =
-    pylint src/xson
-    pycodestyle src/xson --ignore=E501
+    pylint src/xson tests
+    pycodestyle src/xson tests --ignore=E501
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
- List standard modules first in imports.
- Remove unused imports.
- Specify encoding when opening files.
- Avoid shadowing builtins.
- Avoid extra space around dict and list literals.
- Use double blank lines to separate top-level elements.